### PR TITLE
Remove extra newline

### DIFF
--- a/Swish/Sources/ProjectLib/Resources/OpenBytesHeader.txt
+++ b/Swish/Sources/ProjectLib/Resources/OpenBytesHeader.txt
@@ -17,7 +17,6 @@
 //
 // Created by ___FULLUSERNAME___.
 //  ___FILENAME___
-//
-</string>
+//</string>
 </dict>
 </plist>

--- a/Swish/Sources/ProjectLib/Resources/StandardHeader.txt
+++ b/Swish/Sources/ProjectLib/Resources/StandardHeader.txt
@@ -8,7 +8,6 @@
 //
 // Created by ___FULLUSERNAME___.
 //  ___FILENAME___
-//
-</string>
+//</string>
 </dict>
 </plist>


### PR DESCRIPTION
## Description

Remove the extra newline in the file header.

Fixes #30 

## Testing Steps

- Create a new file
- Observe there is no extra newline