### PR TITLE
Add regex check for correct name

### DIFF
--- a/rename.sh
+++ b/rename.sh
@@ -2,12 +2,24 @@
 
 read -p 'Project Name: ' projectvar
 
-grep -rli 'NEW_NAME' scripts/rename-base.sh | xargs -I@ sed -i '' "s/NEW_NAME/$projectvar/g" @
+if [[ "$projectvar" =~ [a-zA-Z_][a-zA-Z_0-9]*$ ]]; then
+    grep -rli 'NEW_NAME' scripts/rename-base.sh | xargs -I@ sed -i '' "s/NEW_NAME/$projectvar/g" @
+    
+    sh ./scripts/rename-base.sh
+    
+    swish appicon
+    swish xcodeproj
+    
+    rm -rf scripts
+    rm rename.sh
+else
+    echo 'Invalid Project Name'
+    echo ''
+    echo 'The project name should only include the following characters:'
+    echo '  - alphanumerics'
+    echo '  - "_"'
+    echo ''
+    echo 'The project name should not start with a number.'
+fi
 
-sh ./scripts/rename-base.sh
 
-swish appicon
-swish xcodeproj
-
-rm -rf scripts
-rm rename.sh


### PR DESCRIPTION
## Description

Adds a project name check to the rename.sh file. This change will not allow people to rename the project if the new name isn't valid. Names should not contain symbols, spaces, or start with a number.

Fixes #18 

## Testing Steps

- Attempt to rename the project using the `rename.sh` file.
- Observe you can't rename to an invalid name.

### Example
```
» ./rename.sh
Project Name: 34
Invalid Project Name

The project name should only include the following characters:
  - alphanumerics
  - "_"

The project name should not start with a number.
```

## Areas of Code Impacted

- `rename.sh`
